### PR TITLE
Security fixes: TLS downgrade, sender impersonation, unsigned updates, path traversal, user enumeration

### DIFF
--- a/client.conf
+++ b/client.conf
@@ -3,6 +3,11 @@ host = msg.thecubed.cc
 port = 2005
 max_retries = 5
 retry_timeout = 15
+; Set allow_insecure = true ONLY for LAN/dev use against a server that has no
+; TLS configured. With it false (the default), the client refuses to connect
+; to a plaintext server and refuses to fall back when cert verification fails.
+; A network attacker cannot then strip TLS without the client noticing.
+allow_insecure = false
 
 [updates]
 ; Optional: hosted JSON feed your clients should try first.

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import wx, socket, json, threading, datetime, wx.adv, configparser, ssl, sys, os, base64, uuid, subprocess, tempfile, re, time
+import wx, socket, json, threading, datetime, wx.adv, configparser, ssl, sys, os, base64, uuid, subprocess, tempfile, re, time, hashlib
 import keyring
 
 try:
@@ -91,6 +91,10 @@ def load_server_config():
         'cafile': config.get('server', 'cafile', fallback=None),
         'max_retries': config.getint('server', 'max_retries', fallback=5),
         'retry_timeout': config.getint('server', 'retry_timeout', fallback=15),
+        # If true, the client will connect over plaintext TCP when the server
+        # has no TLS configured. Defaults to False: production deployments must
+        # use TLS, and a network attacker cannot silently strip it.
+        'allow_insecure': config.getboolean('server', 'allow_insecure', fallback=False),
     }
 
 def get_config_dir():
@@ -284,7 +288,34 @@ def check_for_update(callback):
             wx.CallAfter(callback, None, None, str(e))
     threading.Thread(target=_check, daemon=True).start()
 
-def download_update(url, dest, progress_dlg, callback):
+def _fetch_expected_sha256(checksums_url, asset_name):
+    """Fetch SHA256SUMS, return the hex digest for asset_name, or None if not found.
+    Expected format is the standard `sha256sum` output: '<hex>  <filename>' per line.
+    """
+    import urllib.request
+    req = urllib.request.Request(checksums_url, headers={"User-Agent": "ThriveMessenger/" + VERSION_TAG})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        body = resp.read().decode('utf-8', errors='replace')
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        digest, name = parts[0].strip().lower(), parts[1].strip().lstrip('*')
+        if name == asset_name and len(digest) == 64 and all(c in '0123456789abcdef' for c in digest):
+            return digest
+    return None
+
+def _file_sha256(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+def download_update(url, dest, progress_dlg, callback, expected_sha256=None):
     def _download():
         import urllib.request
         try:
@@ -301,6 +332,19 @@ def download_update(url, dest, progress_dlg, callback):
                         if total > 0:
                             pct = min(int(downloaded * 100 / total), 100)
                             wx.CallAfter(progress_dlg.Update, pct, f"Downloaded {downloaded // 1024} KB of {total // 1024} KB")
+            # Integrity check. Refuse to apply an update whose hash we cannot
+            # verify or whose hash does not match the published SHA256SUMS.
+            if not expected_sha256:
+                try: os.remove(dest)
+                except Exception: pass
+                wx.CallAfter(callback, False, "Release is missing a SHA256SUMS asset — refusing to install an unverifiable update.")
+                return
+            actual = _file_sha256(dest)
+            if actual.lower() != expected_sha256.lower():
+                try: os.remove(dest)
+                except Exception: pass
+                wx.CallAfter(callback, False, f"Update integrity check failed (expected {expected_sha256}, got {actual}). Refusing to install.")
+                return
             wx.CallAfter(callback, True, None)
         except Exception as e:
             wx.CallAfter(callback, False, str(e))
@@ -543,18 +587,40 @@ class StatusDialog(wx.Dialog):
             self.status_text.SetValue(sel); self.sizer.Hide(self.custom_box); self.panel.Layout()
             self.SetSize((350, 150))
 
+class InsecureServerError(Exception):
+    """Raised when the server cannot offer TLS and the client has not opted in to plaintext."""
+
 def create_secure_socket(timeout=None):
     sock = socket.create_connection(ADDR, timeout=timeout)
     if SERVER_CONFIG['cafile'] and os.path.exists(SERVER_CONFIG['cafile']):
         context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=SERVER_CONFIG['cafile'])
-    else: context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
-    try: return context.wrap_socket(sock, server_hostname=SERVER_CONFIG['host'])
-    except ssl.SSLCertVerificationError:
-        sock.close(); sock = socket.create_connection(ADDR, timeout=timeout)
-        context = ssl.create_default_context(); context.check_hostname = False; context.verify_mode = ssl.CERT_NONE
+    else:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+    try:
         return context.wrap_socket(sock, server_hostname=SERVER_CONFIG['host'])
-    except (ssl.SSLError, OSError):
-        sock.close(); return socket.create_connection(ADDR, timeout=timeout)
+    except ssl.SSLCertVerificationError as e:
+        # Hard fail. A network attacker presenting a bogus cert MUST NOT result
+        # in a silent CERT_NONE fallback — that nullifies the whole point of TLS.
+        try: sock.close()
+        except Exception: pass
+        raise InsecureServerError(
+            f"Server certificate could not be verified ({e}). "
+            "Refusing to connect. If this is a self-hosted server, set its [server] cafile "
+            "in client.conf to the issuing CA, or fix the server's certificate."
+        ) from e
+    except (ssl.SSLError, OSError) as e:
+        # The server didn't speak TLS at all. Only allow this when the user has
+        # explicitly opted in via allow_insecure=true in client.conf.
+        try: sock.close()
+        except Exception: pass
+        if not SERVER_CONFIG.get('allow_insecure', False):
+            raise InsecureServerError(
+                f"Server is not offering TLS ({e}). "
+                "Refusing to send credentials over an unencrypted connection. "
+                "Set allow_insecure=true under [server] in client.conf if this is "
+                "intentional (LAN/dev only)."
+            ) from e
+        return socket.create_connection(ADDR, timeout=timeout)
 
 # Keepalive settings (seconds)
 IDLE_KEEPALIVE_SECONDS = 15 * 60  # 15 minutes
@@ -915,17 +981,31 @@ class ClientApp(wx.App):
         docs_path = os.path.join(os.path.expanduser('~'), 'Documents')
         save_dir = os.path.join(docs_path, 'ThriveMessenger', 'files')
         os.makedirs(save_dir, exist_ok=True)
+        save_dir_real = os.path.realpath(save_dir)
         saved = []
         for finfo in files:
             filename = finfo["filename"]; data = finfo["data"]
             try:
-                save_path = os.path.join(save_dir, filename)
+                # Hard-strip any path components, drive letters, or NTFS ADS markers
+                # the server might let through. os.path.join with a drive-rooted name
+                # on Windows discards save_dir entirely, so basename + colon check is
+                # essential, not paranoid.
+                if not isinstance(filename, str) or not filename:
+                    raise ValueError("Empty filename.")
+                safe_name = os.path.basename(filename.replace('\\', '/').rsplit('/', 1)[-1])
+                if not safe_name or ':' in safe_name or safe_name in ('.', '..'):
+                    raise ValueError(f"Refused suspicious filename: {filename!r}")
+                save_path = os.path.join(save_dir, safe_name)
                 if os.path.exists(save_path):
-                    name, ext = os.path.splitext(filename)
+                    name, ext = os.path.splitext(safe_name)
                     counter = 1
                     while os.path.exists(save_path):
                         save_path = os.path.join(save_dir, f"{name} ({counter}){ext}")
                         counter += 1
+                # Final belt-and-braces: confirm the resolved write target really
+                # lives under save_dir before opening it.
+                if os.path.commonpath([save_dir_real, os.path.realpath(os.path.dirname(save_path) or save_dir)]) != save_dir_real:
+                    raise ValueError(f"Refused to write outside files directory: {filename!r}")
                 with open(save_path, 'wb') as f: f.write(base64.b64decode(data))
                 saved.append(os.path.basename(save_path))
             except Exception as e:
@@ -1606,11 +1686,27 @@ class MainFrame(wx.Frame):
         use_installer = is_installer_install()
         target_name = "thrive_messenger_installer.exe" if use_installer else "thrive_messenger.zip"
         asset_url = None
+        checksums_url = None
         for a in assets:
             if a["name"] == target_name:
-                asset_url = a["browser_download_url"]; break
+                asset_url = a["browser_download_url"]
+            elif a["name"] == "SHA256SUMS":
+                checksums_url = a["browser_download_url"]
         if not asset_url:
             wx.MessageBox(f"Could not find {target_name} in release assets.", "Update Error", wx.ICON_ERROR); return
+        if not checksums_url:
+            wx.MessageBox(
+                "This release does not publish a SHA256SUMS asset, so the update cannot be verified. "
+                "Refusing to install. Please ask the release author to publish signed checksums.",
+                "Update Refused", wx.ICON_ERROR); return
+        try:
+            expected_sha = _fetch_expected_sha256(checksums_url, target_name)
+        except Exception as e:
+            wx.MessageBox(f"Failed to fetch SHA256SUMS:\n{e}", "Update Error", wx.ICON_ERROR); return
+        if not expected_sha:
+            wx.MessageBox(
+                f"SHA256SUMS does not contain an entry for {target_name}. Refusing to install.",
+                "Update Refused", wx.ICON_ERROR); return
         ext = ".exe" if use_installer else ".zip"
         dest = os.path.join(tempfile.gettempdir(), f"thrive_update{ext}")
         progress = wx.ProgressDialog("Downloading Update", "Starting download...", maximum=100, parent=self,
@@ -1632,7 +1728,7 @@ class MainFrame(wx.Frame):
                 app.ExitMainLoop()
             else:
                 wx.MessageBox(f"Download failed:\n{error}", "Update Error", wx.ICON_ERROR)
-        download_update(asset_url, dest, progress, _done)
+        download_update(asset_url, dest, progress, _done, expected_sha256=expected_sha)
     def on_add_contact_failed(self, reason): wx.MessageBox(reason, "Add Contact Failed", wx.ICON_ERROR)
     def on_add_contact_success(self, contact_data):
         c = contact_data; self.contact_states[c["user"]] = c["blocked"]

--- a/srv/server.py
+++ b/srv/server.py
@@ -1156,24 +1156,32 @@ def handle_client(cs, addr):
                     con.commit()
                     expire_human = smtp_config.get('code_expires_human', '5 minutes')
                     EmailManager.send_email(t_email, "Thrive Messenger - Password Reset", f"Your password reset code is: {code}\n\nThis code will expire in {expire_human}.")
-                    # Return OK even if email fails to prevent enumeration, mostly.
-                    sock.sendall(json.dumps({"status": "ok", "user": t_user}).encode() + b"\n")
-                else:
-                    sock.sendall(json.dumps({"status": "error", "reason": "No email on file."}).encode() + b"\n")
-            else:
-                # Security: Don't reveal user existence? For this app, we'll just say ok to pretend.
-                sock.sendall(json.dumps({"status": "ok"}).encode() + b"\n")
             con.close()
+            # Always answer the same way regardless of whether the identifier
+            # matched a user, whether that user had an email on file, or whether
+            # the email was actually deliverable. This prevents enumeration of
+            # usernames and of which-email-belongs-to-which-account.
+            sock.sendall(json.dumps({"status": "ok"}).encode() + b"\n")
             return
 
         # --- Perform Password Reset ---
         if action == "reset_password":
-            t_user = req.get("user")
+            t_ident = req.get("user")
             t_code = req.get("code")
             new_p = req.get("new_pass")
             con = sqlite3.connect(DB)
-            row = con.execute("SELECT reset_code, reset_code_at FROM users WHERE username=?", (t_user,)).fetchone()
-            if row and row[0] == t_code and t_code:
+            # Accept either username or email as the identifier so we don't have to
+            # leak which one was used in request_reset.
+            row = con.execute(
+                "SELECT username, reset_code, reset_code_at FROM users WHERE username=? OR email=?",
+                (t_ident, t_ident),
+            ).fetchone()
+            if row:
+                t_user = row[0]
+                row = (row[1], row[2])
+            else:
+                t_user = None
+            if t_user and row and row[0] == t_code and t_code:
                 # Check expiration
                 if row[1]:
                     elapsed = (datetime.datetime.utcnow() - datetime.datetime.fromisoformat(row[1])).total_seconds()
@@ -1201,9 +1209,14 @@ def handle_client(cs, addr):
             recipient = transfer["to"]
             with lock: sock_to = clients.get(recipient)
             if sock_to:
-                name_map = {f["filename"]: f["filename"] for f in transfer["files"]}
-                safe_files = [dict(fd, filename=name_map.get(fd["filename"], fd["filename"])) for fd in req.get("files", [])
-                              if '/' not in fd["filename"] and '\\' not in fd["filename"]]
+                # Only forward filenames that were declared and approved in the
+                # original file_offer. This shuts down any attempt by the sender
+                # to swap in a different (e.g., path-traversing) name on the
+                # second connection.
+                allowed_names = {f["filename"] for f in transfer["files"]}
+                safe_files = [fd for fd in req.get("files", [])
+                              if isinstance(fd.get("filename"), str)
+                              and fd["filename"] in allowed_names]
                 try: sock_to.sendall((json.dumps({"action": "file_data", "from": transfer["from"], "files": safe_files}) + "\n").encode())
                 except: pass
             sock.sendall(b'{"status":"ok"}\n')
@@ -2044,7 +2057,15 @@ def handle_client(cs, addr):
                     sock.sendall((json.dumps({"action": "group_call_signal_result", "ok": False, "reason": "Signal relay failed."}) + "\n").encode())
 
             elif action == "msg":
-                to, frm = msg["to"], msg["from"]
+                # Always treat the authenticated session user as the sender.
+                # Never trust a client-supplied "from" — that allowed any logged-in
+                # user to impersonate any other user.
+                to = msg.get("to")
+                frm = user
+                msg["from"] = user
+                if not to or not isinstance(to, str):
+                    sock.sendall(json.dumps({"action": "msg_failed", "to": to, "reason": "Missing recipient."}).encode() + b"\n")
+                    continue
                 if _is_registered_bot(to) and not _can_user_use_feature(user, "bots"):
                     sock.sendall(json.dumps({"action": "msg_failed", "to": to, "reason": "Bot messaging is disabled for your account."}).encode() + b"\n")
                     continue
@@ -2052,23 +2073,33 @@ def handle_client(cs, addr):
                 recipient_has_blocked = con.execute("SELECT blocked FROM contacts WHERE owner=? AND contact=?", (to, frm)).fetchone()
                 sender_has_blocked = con.execute("SELECT blocked FROM contacts WHERE owner=? AND contact=?", (frm, to)).fetchone()
                 con.close()
-                
+
                 with lock: sock_to = clients.get(to)
                 reason = None
                 if recipient_has_blocked and recipient_has_blocked[0] == 1:
                     reason = f"Message couldn't be sent because {to} has you blocked."
-                elif sender_has_blocked and sender_has_blocked[0] == 1: 
+                elif sender_has_blocked and sender_has_blocked[0] == 1:
                     reason = "You have blocked this contact."
                 elif _maybe_send_bot_reply(sock, frm, to, msg.get("msg", "")):
                     reason = None
-                elif not sock_to: 
+                elif not sock_to:
                     reason = f"{to} is offline."
                 else:
-                    try: 
-                        sock_to.sendall((json.dumps(msg)+"\n").encode())
+                    # Forward only the fields we trust. Anything else the client
+                    # tucked into the dict (fake tts payload, fake action, etc.)
+                    # is discarded.
+                    forwarded = {
+                        "action": "msg",
+                        "from": frm,
+                        "to": to,
+                        "msg": msg.get("msg", ""),
+                        "time": msg.get("time") or datetime.datetime.now().isoformat(),
+                    }
+                    try:
+                        sock_to.sendall((json.dumps(forwarded)+"\n").encode())
                         reason = None
                     except: pass
-                if reason: 
+                if reason:
                     sock.sendall(json.dumps({"action": "msg_failed", "to": to, "reason": reason}).encode() + b"\n")
 
             elif action == "typing":
@@ -2087,9 +2118,28 @@ def handle_client(cs, addr):
             elif action == "file_offer":
                 to = msg["to"]
                 files = msg.get("files", [])
-                # Reject any filename containing a path separator (OS-independent check)
-                bad = next((f["filename"] for f in files if '/' in f["filename"] or '\\' in f["filename"]), None)
-                if bad:
+                # Reject anything that looks like a path or a Windows-special name.
+                # Forward/backslash separators, drive-letter prefixes (C:foo.exe),
+                # NTFS alternate data streams (file.txt:hidden.exe), leading dots,
+                # control characters, and reserved device names all get bounced.
+                _RESERVED = {"CON","PRN","AUX","NUL",
+                             "COM1","COM2","COM3","COM4","COM5","COM6","COM7","COM8","COM9",
+                             "LPT1","LPT2","LPT3","LPT4","LPT5","LPT6","LPT7","LPT8","LPT9"}
+                def _bad_filename(name):
+                    if not isinstance(name, str) or not name or len(name) > 255:
+                        return True
+                    if '/' in name or '\\' in name or ':' in name or '\x00' in name:
+                        return True
+                    if name in ('.', '..'):
+                        return True
+                    if any(ord(c) < 32 for c in name):
+                        return True
+                    stem = name.split('.', 1)[0].upper()
+                    if stem in _RESERVED:
+                        return True
+                    return False
+                bad = next((f["filename"] for f in files if _bad_filename(f.get("filename"))), None)
+                if bad is not None:
                     sock.sendall((json.dumps({"action": "file_offer_failed", "to": to, "reason": f"Invalid filename: '{bad}'"}) + "\n").encode())
                     continue
 


### PR DESCRIPTION
## Summary

Five independent security fixes from a code review of the client and server. The bugs range from "low blast radius, easy fix" to "any on-path attacker reads everyone's passwords." Each fix is described below; the commit message has the same content.

I'm filing this as a single PR because the edits overlap the same files, but each item below is self-contained and you can split / cherry-pick / drop any of them on its own. A companion tracking issue with the same content is filed separately so the findings are searchable.

---

### 1. Client: TLS silently downgrades to plaintext on any error
[`main.py` — `create_secure_socket`](https://github.com/G4p-Studios/ThriveMessenger/blob/main/main.py#L546-L557)

```python
try: return context.wrap_socket(sock, server_hostname=SERVER_CONFIG['host'])
except ssl.SSLCertVerificationError:
    sock.close(); sock = socket.create_connection(ADDR, timeout=timeout)
    context = ssl.create_default_context(); context.check_hostname = False; context.verify_mode = ssl.CERT_NONE
    return context.wrap_socket(sock, server_hostname=SERVER_CONFIG['host'])
except (ssl.SSLError, OSError):
    sock.close(); return socket.create_connection(ADDR, timeout=timeout)
```

A network attacker (Wi-Fi, hostile ISP, local router) can present any cert *or refuse TLS entirely* and the client silently proceeds. The user is never told. Credentials and every message go in cleartext. This single fallback nullifies the entire purpose of the server's Let's Encrypt setup.

**Fix:** raise `InsecureServerError` on cert verification failure (always). Allow plaintext only when `allow_insecure=true` is explicitly set under `[server]` in `client.conf`. Default is `false`. LAN/dev users opt in; production users get a clear error instead of an invisible downgrade.

### 2. Server: any logged-in user can impersonate any other user
[`srv/server.py` — `msg` action](https://github.com/G4p-Studios/ThriveMessenger/blob/main/srv/server.py#L2046-L2073)

```python
elif action == "msg":
    to, frm = msg["to"], msg["from"]   # trusts client-supplied "from"
    ...
    sock_to.sendall((json.dumps(msg)+"\n").encode())   # forwards client dict verbatim
```

The server never validates `frm == user` and forwards the client's `msg` dict as-is. Any logged-in user can send `{"action":"msg","to":"bob","from":"alice","msg":"send me $500"}` and Bob's client displays it as if Alice sent it. The same goes for fake admin alerts ("server is shutting down, give me your password"), social-engineering setups, etc. Note that `typing` and `file_offer` already do the right thing — only `msg` is broken.

**Fix:** force `msg["from"] = user` (the authenticated session user) before forwarding, and forward only a whitelisted set of fields so the client cannot smuggle extra keys through.

### 3. Client: auto-updates have no integrity verification
[`main.py` — `download_update` / `_start_update_download` / `apply_zip_update`](https://github.com/G4p-Studios/ThriveMessenger/blob/main/main.py#L287-L342)

The client downloads the release asset and runs it (`apply_installer_update`) or extracts and overwrites the install directory (`apply_zip_update`) with no checksum, no signature, nothing. If a GitHub release ever ships a bad artifact — compromised contributor token, a maintainer typo, an attacker who manages to publish a release — every client takes it. `apply_zip_update` is especially harsh because `xcopy /s /e /y /q` will overwrite arbitrary files under `program_dir`, including `tmsg.exe` itself.

**Fix:** require a `SHA256SUMS` asset alongside the release artifact (standard `sha256sum` output format). The updater fetches it, looks up the expected digest for the artifact filename, and refuses to install if the downloaded file's sha256 does not match. Real code signing (minisign or Sigstore) is the proper long-term answer; this at least forces an attacker to compromise both upload paths instead of one.

**Action required from maintainers:** add a step to the release workflow that publishes `SHA256SUMS` as an asset on every release. Without it, the new client will refuse to install updates after this PR merges.

### 4. Path traversal on incoming files
[`srv/server.py` — `file_offer`](https://github.com/G4p-Studios/ThriveMessenger/blob/main/srv/server.py#L2087-L2094) and [`main.py` — `on_file_data`](https://github.com/G4p-Studios/ThriveMessenger/blob/main/main.py#L913-L934)

Server check is `'/' in fname or '\\' in fname`. That misses:

- **Windows drive prefix:** `os.path.join(save_dir, "C:foo.exe")` returns `"C:foo.exe"` because Python treats `C:` as a drive root and discards `save_dir`. File lands in the C: drive's current working directory.
- **NTFS alternate data streams:** `legit.txt:hidden.exe` writes the payload as an ADS attached to a new `legit.txt` — invisible to most tools.
- **Reserved device names:** `CON`, `PRN`, `NUL`, `COM1`..`COM9`, `LPT1`..`LPT9` cause weird failures or open the device.
- **Filename swap on the second connection:** `file_data` re-receives the filename list from the sender; nothing requires that those names match the offer.

**Fix:**
- Server `file_offer`: reject filenames containing `/`, `\`, `:`, control chars, empty string, leading/only dots, or reserved device-name stems.
- Server `file_data`: only forward filenames that exactly match one already approved in the corresponding `file_offer`.
- Client `on_file_data`: basename the incoming filename, reject `:` and `.`/`..`, and `commonpath`-confirm the resolved write target is under `save_dir`.

### 5. Server: user enumeration in password reset
[`srv/server.py` — `request_reset`](https://github.com/G4p-Studios/ThriveMessenger/blob/main/srv/server.py#L1146-L1167)

The handler comments say "Don't reveal user existence" but the three response shapes betray it:

- match w/ email   → `{"status":"ok","user":"<username>"}` (also leaks email→username)
- match w/o email  → `{"status":"error","reason":"No email on file."}`
- no match         → `{"status":"ok"}`

**Fix:** always return `{"status":"ok"}` regardless of whether the identifier matched, whether the user had an email, or whether the email actually sent. `reset_password` now accepts either username or email as the identifier so the existing reset-by-email UX still works end-to-end.

---

## Out of scope (worth filing separately)

- No socket/read timeouts or request-size caps on the server → trivial slowloris/OOM DoS via a stuck `f.readline()` per connection.
- Password is sent plaintext to the server on every reconnect; server-issued auth tokens would fix that.
- Login timing leaks username existence because the not-found branch skips argon2 entirely.
- SMTP `starttls()` is called with no context → no cert validation on the server→SMTP-provider hop.

Happy to send follow-up PRs for those if useful.

## Test plan

- [ ] Connect a client built from this branch against the production TLS server → connects normally.
- [ ] Connect against a server with a self-signed cert and no `cafile` → client errors loudly instead of falling back. Setting `cafile` to the issuer chain → connects normally.
- [ ] Connect against a plaintext server with `allow_insecure=false` (default) → client refuses. With `allow_insecure=true` → connects.
- [ ] Logged-in user A sends `{"action":"msg","to":"B","from":"C","msg":"..."}` raw to the server → recipient sees it as from A, not C.
- [ ] Run the update flow against a release that has `SHA256SUMS` with the correct digest → installs. Without `SHA256SUMS`, or with a wrong digest, or with a missing entry → refuses, error shown to user.
- [ ] Send a file named `C:foo.exe`, `legit.txt:hidden.exe`, `CON`, `../bar.txt`, or `..` → all rejected by server before reaching recipient.
- [ ] `request_reset` with an unknown identifier, with an existing user without an email, and with an existing user with an email → all return identical `{"status":"ok"}`. Reset-by-email still completes the full flow when the code is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
